### PR TITLE
Add exception for handling invalid request token

### DIFF
--- a/src/core/services/core-process-response.service.ts
+++ b/src/core/services/core-process-response.service.ts
@@ -5,6 +5,7 @@ import {
   NotFoundError,
   UserUnauthorizedError,
   InvalidParametersError,
+  InvalidRequestTokenError,
   InternalServerError,
   APIError,
 } from '../../errors';
@@ -17,6 +18,10 @@ const RESPONSE_ERRORS = {
   '404': NotFoundError,
   '419': UserUnauthorizedError,
   '422': InvalidParametersError,
+};
+
+const RESPONSE_SUB_ERRORS = {
+  'invalid_request_token': InvalidRequestTokenError
 };
 
 // The body on the request is a stream and can only be
@@ -58,7 +63,10 @@ export const CoreProcessResponseService = {
       );
     }
 
-    const err = RESPONSE_ERRORS[response.status.toString()];
+    // Throw a special exception for subtype errors if defined. Eg. for
+    // invalid request token, which is a subtype of InvalidParametersError.
+    // Otherwise, throw exception as defined per status code
+    let err = RESPONSE_SUB_ERRORS[body.type] || RESPONSE_ERRORS[response.status.toString()];
 
     throw new err(`Castle: Responded with ${response.status} code`);
   },

--- a/src/core/services/core-process-response.service.ts
+++ b/src/core/services/core-process-response.service.ts
@@ -66,7 +66,7 @@ export const CoreProcessResponseService = {
     // Throw a special exception for subtype errors if defined. Eg. for
     // invalid request token, which is a subtype of InvalidParametersError.
     // Otherwise, throw exception as defined per status code
-    let err = RESPONSE_SUB_ERRORS[body.type] || RESPONSE_ERRORS[response.status.toString()];
+    const err = RESPONSE_SUB_ERRORS[body.type] || RESPONSE_ERRORS[response.status.toString()];
 
     throw new err(`Castle: Responded with ${response.status} code`);
   },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -60,6 +60,14 @@ export class InvalidParametersError extends APIError {
   }
 }
 
+// api error invalid param 422, subtype
+export class InvalidRequestTokenError extends InvalidParametersError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidRequestTokenError';
+  }
+}
+
 // all internal server errors
 export class InternalServerError extends APIError {
   constructor(message: string) {

--- a/test/core/services/core-process-response.service.test.ts
+++ b/test/core/services/core-process-response.service.test.ts
@@ -1,5 +1,6 @@
 import { CoreProcessResponseService } from '../../../src/core/core.module';
 import { Response } from 'node-fetch';
+import { InvalidRequestTokenError } from '../../../src/errors';
 
 describe('CoreProcessResponseService', () => {
   describe('call', () => {
@@ -179,6 +180,24 @@ describe('CoreProcessResponseService', () => {
             );
           });
         });
+      });
+
+      describe('with invalid request token', () => {
+        const response = new Response(JSON.stringify({
+          type: "invalid_request_token",
+          message: "Invalid Request Token"
+        }), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 422
+        })
+
+        it('throws InvalidRequestTokenError', async () => {
+          await expect(
+            CoreProcessResponseService.call('risk', {}, response, {
+              info: () => {},
+            })
+          ).rejects.toThrow(InvalidRequestTokenError)
+        })
       });
     });
   });


### PR DESCRIPTION
Introduce a separate exception `InvalidRequestTokenError` for handling missing or invalid request token. Per default, Castle recommends rejecting these requests, as opposed to other 422 status errors, which are indicators of integration errors.

Example usage:
```javascript
try {
  castle.risk(...)
} catch (e) {
  if (e instanceof InvalidRequestTokenError) {
     // Block request
  } else if (e instanceof InvalidParametersError) {
     // Data missing or invalid. Needs to be fixed
  }
}
```