### PR TITLE
fix: Filter API error handling and types

### DIFF
--- a/src/api/services/api-filter.service.ts
+++ b/src/api/services/api-filter.service.ts
@@ -7,7 +7,6 @@ import { APIService } from './api.service';
 import AbortController from 'abort-controller';
 
 const handleFailover = (
-  userId: string,
   reason: string,
   configuration: Configuration,
   err?: Error
@@ -18,7 +17,6 @@ const handleFailover = (
   if (configuration.failoverStrategy === FailoverStrategy.throw) {
     throw err;
   }
-
   return {
     policy: {
       action: configuration.failoverStrategy,
@@ -52,9 +50,9 @@ export const APIFilterService = {
       );
     } catch (e) {
       if (isTimeoutError(e)) {
-        return handleFailover(options.user.id, 'timeout', configuration, e);
+        return handleFailover('timeout', configuration, e);
       } else if (e instanceof InternalServerError) {
-        return handleFailover(options.user.id, 'server error', configuration);
+        return handleFailover('server error', configuration, e);
       } else {
         throw e;
       }

--- a/src/payload/models/filter_payload.ts
+++ b/src/payload/models/filter_payload.ts
@@ -13,4 +13,10 @@ export interface FilterPayload {
     ip: string;
     headers: IncomingHttpHeaders | { [key: string]: string | boolean };
   };
+  matching_user_id?: string;
+  params?: {
+    email?: string;
+    phone?: string;
+    username?: string;
+  }
 }

--- a/src/payload/models/risk_payload.ts
+++ b/src/payload/models/risk_payload.ts
@@ -6,7 +6,7 @@ export interface RiskPayload {
   status: string;
   user: {
     id: string;
-    email: string;
+    email?: string;
     registered_at?: string;
     traits?: object;
     name?: string;


### PR DESCRIPTION
According to the available [API Spec](https://reference.castle.io/#operation/filter), the Filter API doesn't expect a `user.id`, thus the `handleFailover` method for the Filter API shouldn't either.
Also I've added some relevant missing attributes from the payload, but I wasn't thorough. There's plenty more missing like `product`, `session` and `authentication_method`