### PR TITLE
feat: export configuration types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 export { Castle } from './src/Castle';
+export { ConfigurationProperties as CastleConfiguration } from './src/configuration';
 export * from './src/constants';
 export * from './src/errors';
 export { FailoverStrategy } from './src/failover/failover.module';

--- a/src/Castle.ts
+++ b/src/Castle.ts
@@ -17,7 +17,7 @@ import type {
   FilterPayload,
   RiskPayload,
 } from './payload/payload.module';
-import { Configuration } from './configuraton';
+import { Configuration } from './configuration';
 
 export class Castle {
   public configuration: Configuration;

--- a/src/Castle.ts
+++ b/src/Castle.ts
@@ -17,12 +17,12 @@ import type {
   FilterPayload,
   RiskPayload,
 } from './payload/payload.module';
-import { Configuration } from './configuration';
+import { Configuration, ConfigurationProperties } from './configuration';
 
 export class Castle {
   public configuration: Configuration;
 
-  constructor(configAttributes) {
+  constructor(configAttributes: ConfigurationProperties) {
     this.configuration = new Configuration(configAttributes);
   }
 

--- a/src/api/services/api-approve-device.service.ts
+++ b/src/api/services/api-approve-device.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandApproveDeviceService } from '../../command/command.module';
 import { Payload } from '../../payload/payload.module';
 import { APIService } from './api.service';

--- a/src/api/services/api-authenticate.service.ts
+++ b/src/api/services/api-authenticate.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { InternalServerError } from '../../errors';
 import { AuthenticateResult } from '../../models';
 import { CommandAuthenticateService } from '../../command/command.module';

--- a/src/api/services/api-filter.service.ts
+++ b/src/api/services/api-filter.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { InternalServerError } from '../../errors';
 import { CommandFilterService } from '../../command/command.module';
 import { FailoverStrategy } from '../../failover/failover.module';

--- a/src/api/services/api-get-device.service.ts
+++ b/src/api/services/api-get-device.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandGetDeviceService } from '../../command/command.module';
 import { Payload } from '../../payload/payload.module';
 import { APIService } from './api.service';

--- a/src/api/services/api-get-devices-for-user.service.ts
+++ b/src/api/services/api-get-devices-for-user.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandGetDevicesForUserService } from '../../command/command.module';
 import { Payload } from '../../payload/payload.module';
 import { APIService } from './api.service';

--- a/src/api/services/api-log.service.ts
+++ b/src/api/services/api-log.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandLogService } from '../../command/command.module';
 import { LogPayload } from '../../payload/payload.module';
 import { APIService } from './api.service';

--- a/src/api/services/api-report-device.service.ts
+++ b/src/api/services/api-report-device.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandReportDeviceService } from '../../command/command.module';
 import { Payload } from '../../payload/payload.module';
 import { APIService } from './api.service';

--- a/src/api/services/api-risk.service.ts
+++ b/src/api/services/api-risk.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { InternalServerError } from '../../errors';
 import { CommandRiskService } from '../../command/command.module';
 import { FailoverStrategy } from '../../failover/failover.module';

--- a/src/api/services/api-track.service.ts
+++ b/src/api/services/api-track.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandTrackService } from '../../command/command.module';
 import { Payload } from '../../payload/payload.module';
 import { APIService } from './api.service';

--- a/src/api/services/api.service.ts
+++ b/src/api/services/api.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CoreProcessResponseService } from '../../core/core.module';
 import { LoggerService } from '../../logger/logger.module';
 import AbortController from 'abort-controller';

--- a/src/command/services/command-approve-device.service.ts
+++ b/src/command/services/command-approve-device.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandGenerateService } from './command-generate.service';
 import { Payload } from '../../payload/payload.module';
 import { ValidatorPresentService } from '../../validator/validator.module';

--- a/src/command/services/command-authenticate.service.ts
+++ b/src/command/services/command-authenticate.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextSanitizeService } from '../../context/context.module';
 import type { Payload } from '../../payload/payload.module';
 import { CommandGenerateService } from './command-generate.service';

--- a/src/command/services/command-filter.service.ts
+++ b/src/command/services/command-filter.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextSanitizeService } from '../../context/context.module';
 import { FilterPayload } from '../../payload/payload.module';
 import { CommandGenerateService } from './command-generate.service';

--- a/src/command/services/command-generate.service.ts
+++ b/src/command/services/command-generate.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import {
   CoreGenerateDefaultHeadersService,
   CoreGenerateRequestBody,

--- a/src/command/services/command-get-device.service.ts
+++ b/src/command/services/command-get-device.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandGenerateService } from './command-generate.service';
 import { Payload } from '../../payload/payload.module';
 import { ValidatorPresentService } from '../../validator/validator.module';

--- a/src/command/services/command-get-devices-for-user.service.ts
+++ b/src/command/services/command-get-devices-for-user.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandGenerateService } from './command-generate.service';
 import { Payload } from '../../payload/payload.module';
 import { ValidatorPresentService } from '../../validator/validator.module';

--- a/src/command/services/command-log.service.ts
+++ b/src/command/services/command-log.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextSanitizeService } from '../../context/context.module';
 import { LogPayload } from '../../payload/payload.module';
 import { CommandGenerateService } from './command-generate.service';

--- a/src/command/services/command-report-device.service.ts
+++ b/src/command/services/command-report-device.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { CommandGenerateService } from './command-generate.service';
 import { Payload } from '../../payload/payload.module';
 import { ValidatorPresentService } from '../../validator/validator.module';

--- a/src/command/services/command-risk.service.ts
+++ b/src/command/services/command-risk.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextSanitizeService } from '../../context/context.module';
 import { CommandGenerateService } from './command-generate.service';
 import { RiskPayload } from '../../payload/payload.module';

--- a/src/command/services/command-track.service.ts
+++ b/src/command/services/command-track.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextSanitizeService } from '../../context/context.module';
 import { Payload } from '../../payload/payload.module';
 import { CommandGenerateService } from './command-generate.service';

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -6,7 +6,7 @@ import { DEFAULT_API_URL, DEFAULT_TIMEOUT } from './constants';
 import { ConfigurationError } from './errors';
 import { FailoverStrategy } from './failover/models/failover-strategy';
 
-interface ConfigurationProperties {
+export interface ConfigurationProperties {
   apiSecret: string;
   baseUrl?: string;
   timeout?: number;

--- a/src/context/services/context-get-default.service.ts
+++ b/src/context/services/context-get-default.service.ts
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash.isempty';
 import get from 'lodash.get';
 import pickBy from 'lodash.pickby';
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ClientIdExtractService } from '../../client-id/client-id.module';
 import { HeadersExtractService } from '../../headers/headers.module';
 import { IPsExtractService } from '../../ips/ips.module';

--- a/src/context/services/context-prepare.service.ts
+++ b/src/context/services/context-prepare.service.ts
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextGetDefaultService } from './context-get-default.service';
 import type { Request as ExpressRequest } from 'express';
 

--- a/src/core/services/core-generate-default-headers.service.ts
+++ b/src/core/services/core-generate-default-headers.service.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 
 export const CoreGenerateDefaultHeadersService = {
   call: (configuration: Configuration) => {

--- a/src/headers/services/headers-extract.service.ts
+++ b/src/headers/services/headers-extract.service.ts
@@ -1,6 +1,6 @@
 import type { IncomingHttpHeaders } from 'http2';
 import reduce from 'lodash.reduce';
-import type { Configuration } from '../../configuraton';
+import type { Configuration } from '../../configuration';
 
 const ALWAYS_ALLOWLISTED = ['user-agent'];
 const ALWAYS_DENYLISTED = ['cookie', 'authorization'];

--- a/src/ips/services/ips-extract.service.ts
+++ b/src/ips/services/ips-extract.service.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from 'http2';
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { TRUSTED_PROXIES } from '../../constants';
 
 // ordered list of ip headers for ip extraction

--- a/src/payload/services/payload-prepare-service.ts
+++ b/src/payload/services/payload-prepare-service.ts
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import { Configuration } from '../../configuraton';
+import { Configuration } from '../../configuration';
 import { ContextPrepareService } from '../../context/context.module';
 import type { Request } from 'express';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "outDir": "dist",
     "rootDir": ".",
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true
   },
   "compileOnSave": true,
   "buildOnSave": true,


### PR DESCRIPTION
- Changed TSConfig to expose declaration file.
- Exposed `Castle`'s configuration as `CastleConfiguration`. Feel free to choose another name. 
- Fixed typo in file name `s/configuraton/configuration`
- Adds types to `Castle` constructor arguments

> This time I'll ask you to keep the `COMMIT_AUTHOR` if you wish to push the code to `master` 👍🏽 