### PR TITLE
feat: add create list items endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf dist",
     "build": "tsc",
     "start": "tsc -w",
-    "test": "jest --runInBand",
+    "test": "jest",
     "lint-fix": "eslint --fix --quiet '{src,test}/**/*.{js,ts,tsx}' '*.{js,ts,tsx}'",
     "lint-verify": "eslint '{src,test}/**/*.{js,ts,tsx}' '*.{js,ts,tsx}'",
     "prepush": "yarn build && yarn lint-fix && yarn prettier-verify",

--- a/src/Castle.ts
+++ b/src/Castle.ts
@@ -9,6 +9,7 @@ import {
   APILogService,
   APIFilterService,
   APIRiskService,
+  APICreateListItemService,
 } from './api/api.module';
 import { FailoverStrategy } from './failover/failover.module';
 import type {
@@ -18,6 +19,7 @@ import type {
   RiskPayload,
 } from './payload/payload.module';
 import { Configuration, ConfigurationProperties } from './configuration';
+import { ListItemPayload } from './payload/models/list_item_payload';
 
 export class Castle {
   public configuration: Configuration;
@@ -90,6 +92,10 @@ export class Castle {
 
   public async reportDevice({ device_token }: Payload): Promise<any> {
     return APIReportDeviceService.call({ device_token }, this.configuration);
+  }
+
+  public async createListItem(params: ListItemPayload): Promise<any> {
+    return APICreateListItemService.call(params, this.configuration);
   }
 
   private generateDoNotTrackResponse(userId): object {

--- a/src/api/services/api-create-list-item.service.ts
+++ b/src/api/services/api-create-list-item.service.ts
@@ -1,0 +1,21 @@
+import { Configuration } from '../../configuration';
+import { CommandCreateListItemService } from '../../command/command.module';
+import { APIService } from './api.service';
+import AbortController from 'abort-controller';
+import { ListItemPayload } from '../../payload/models/list_item_payload';
+
+export const APICreateListItemService = {
+  call: async (
+    options: ListItemPayload,
+    configuration: Configuration
+  ): Promise<any> => {
+    const controller = new AbortController();
+    const command = CommandCreateListItemService.call(
+      controller,
+      options,
+      configuration
+    );
+
+    return APIService.call(controller, command, configuration);
+  },
+};

--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -8,3 +8,4 @@ export * from './api-track.service';
 export * from './api-risk.service';
 export * from './api-log.service';
 export * from './api-filter.service';
+export * from './api-create-list-item.service';

--- a/src/command/services/command-create-list-item.service.ts
+++ b/src/command/services/command-create-list-item.service.ts
@@ -9,11 +9,7 @@ export const CommandCreateListItemService = {
     options: ListItemPayload,
     configuration: Configuration
   ) => {
-    ValidatorPresentService.call(options, [
-      'list_id',
-      'primary_value',
-      'author',
-    ]);
+    ValidatorPresentService.call(options, ['list_id']);
 
     return CommandGenerateService.call(
       controller,

--- a/src/command/services/command-create-list-item.service.ts
+++ b/src/command/services/command-create-list-item.service.ts
@@ -1,0 +1,26 @@
+import { Configuration } from '../../configuration';
+import { CommandGenerateService } from './command-generate.service';
+import { ValidatorPresentService } from '../../validator/validator.module';
+import { ListItemPayload } from '../../payload/models/list_item_payload';
+
+export const CommandCreateListItemService = {
+  call: (
+    controller,
+    options: ListItemPayload,
+    configuration: Configuration
+  ) => {
+    ValidatorPresentService.call(options, [
+      'list_id',
+      'primary_value',
+      'author',
+    ]);
+
+    return CommandGenerateService.call(
+      controller,
+      `lists/${options.list_id}/items`,
+      options,
+      'POST',
+      configuration
+    );
+  },
+};

--- a/src/command/services/command-generate.service.ts
+++ b/src/command/services/command-generate.service.ts
@@ -8,6 +8,7 @@ import {
   LogPayload,
   RiskPayload,
   FilterPayload,
+  ListItemPayload,
 } from '../../payload/payload.module';
 
 const combineURLs = (baseURL, relativeURL) => {
@@ -18,7 +19,12 @@ export const CommandGenerateService = {
   call: (
     controller,
     path: string,
-    options: Payload | LogPayload | RiskPayload | FilterPayload,
+    options:
+      | Payload
+      | LogPayload
+      | RiskPayload
+      | FilterPayload
+      | ListItemPayload,
     method: string,
     configuration: Configuration
   ) => {

--- a/src/command/services/index.ts
+++ b/src/command/services/index.ts
@@ -8,3 +8,4 @@ export * from './command-track.service';
 export * from './command-filter.service';
 export * from './command-log.service';
 export * from './command-risk.service';
+export * from './command-create-list-item.service';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,3 +3,4 @@ export * from './risk-policy';
 export * from './signals';
 export * from './device';
 export * from './verdict';
+export * from './list-item';

--- a/src/models/list-item.ts
+++ b/src/models/list-item.ts
@@ -1,0 +1,16 @@
+import { ListItemAuthorType } from '../payload/models/list_item_payload';
+
+export interface ListItem {
+  id: string;
+  list_id: string;
+  primary_value: string;
+  secondary_value?: string;
+  comment?: string;
+  author: {
+    type: ListItemAuthorType;
+    identifier: string;
+  };
+  auto_archives_at?: string;
+  archived?: boolean;
+  created_at?: string;
+}

--- a/src/payload/models/index.ts
+++ b/src/payload/models/index.ts
@@ -2,3 +2,4 @@ export * from './payload';
 export * from './filter_payload';
 export * from './log_payload';
 export * from './risk_payload';
+export * from './list_item_payload';

--- a/src/payload/models/list_item_payload.ts
+++ b/src/payload/models/list_item_payload.ts
@@ -1,0 +1,26 @@
+export type ListItemAuthorType =
+  | '$analyst_email'
+  | '$castle_dashboard_user'
+  | '$castle_policy'
+  | '$user'
+  | '$user_email'
+  | '$other';
+
+export type ListItemMode =
+  | '$error'
+  | '$replace'
+  | '$update'
+  | '$update_or_replace';
+
+export type ListItemPayload = {
+  list_id: string;
+  primary_value: string;
+  author: {
+    type: ListItemAuthorType;
+    identifier: string;
+  };
+  secondary_value?: string;
+  comment?: string;
+  auto_archives_at?: string;
+  mode?: ListItemMode;
+};

--- a/test/api/services/api-create-list-item.service.test.ts
+++ b/test/api/services/api-create-list-item.service.test.ts
@@ -1,0 +1,56 @@
+import { APICreateListItemService } from '../../../src/api/api.module';
+import { Configuration } from '../../../src/configuration';
+import fetchMock from 'fetch-mock';
+import { ListItemAuthorType, ListItemMode } from '../../../src/payload/models';
+
+describe('APICreateListItemService', () => {
+  const sampleRequestData = {
+    list_id: 'e6baae3a-0636-441a-ba4f-c73f266c7a17',
+    primary_value: 'A04t7AcfSA69cBTTusx0RQ',
+    secondary_value: '2ee938c8-24c2-4c26-9d25-19511dd75029',
+    comment: 'Fradulent user found through automated inspection',
+    author: {
+      type: '$other' as ListItemAuthorType,
+      identifier: 'Security bot',
+    },
+    mode: '$error' as ListItemMode,
+  };
+
+  describe('call', () => {
+    it('handles create list item response', async () => {
+      const createListItemResponse = {
+        primary_value: 'A04t7AcfSA69cBTTusx0RQ',
+        secondary_value: '2ee938c8-24c2-4c26-9d25-19511dd75029',
+        comment: 'Fradulent user found through manual inspection',
+        author: {
+          type: '$analyst_email',
+          identifier: 'string',
+        },
+        auto_archives_at: '2021-09-27T16:46:38.313Z',
+        id: '2ee938c8-24c2-4c26-9d25-19511dd75029',
+        list_id: '2ee938c8-24c2-4c26-9d25-19511dd75029',
+        archived: true,
+        created_at: '2021-09-27T16:46:38.313Z',
+      };
+
+      const fetch = fetchMock
+        .sandbox()
+        .mock(
+          `path:/v1/lists/${sampleRequestData.list_id}/items`,
+          createListItemResponse
+        );
+
+      const config = new Configuration({
+        apiSecret: 'test',
+        overrideFetch: fetch,
+        logger: { info: () => {} },
+      });
+
+      const response = await APICreateListItemService.call(
+        sampleRequestData,
+        config
+      );
+      expect(response).toEqual(createListItemResponse);
+    });
+  });
+});

--- a/test/command/services/command-create-list-item.service.test.ts
+++ b/test/command/services/command-create-list-item.service.test.ts
@@ -1,0 +1,75 @@
+import { CommandCreateListItemService } from '../../../src/command/command.module';
+import { Configuration } from '../../../src/configuration';
+import AbortController from 'abort-controller';
+import { ListItemAuthorType, ListItemMode } from '../../../src/payload/models';
+import MockDate from 'mockdate';
+import { InvalidParametersError } from '../../../src/errors';
+
+describe('CommandCreateListItem', () => {
+  beforeEach(() => {
+    MockDate.set(new Date('2023-04-15T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+  describe('call', () => {
+    const controller = new AbortController();
+
+    const options = {
+      list_id: 'e6baae3a-0636-441a-ba4f-c73f266c7a17',
+      primary_value: 'A04t7AcfSA69cBTTusx0RQ',
+      secondary_value: '2ee938c8-24c2-4c26-9d25-19511dd75029',
+      comment: 'Fradulent user found through automated inspection',
+      author: {
+        type: '$other' as ListItemAuthorType,
+        identifier: 'Security bot',
+      },
+      mode: '$error' as ListItemMode,
+    };
+
+    const expected = {
+      requestUrl: new URL(
+        `https://castle.io/v1/lists/${options.list_id}/items`
+      ),
+      requestOptions: {
+        signal: controller.signal,
+        method: 'POST',
+        headers: {
+          Authorization: 'Basic OnRlc3Q=',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          sent_at: '2023-04-15T00:00:00.000Z',
+          ...options,
+        }),
+      },
+    };
+
+    const config = new Configuration({
+      apiSecret: 'test',
+      baseUrl: 'https://castle.io/v1',
+    });
+
+    it('generates payload', () => {
+      const received = CommandCreateListItemService.call(
+        controller,
+        options,
+        config
+      );
+      expect(received.requestUrl.href).toEqual(expected.requestUrl.href);
+      expect(received).toMatchObject(expected);
+    });
+
+    test.each(['list_id', 'primary_value', 'author'])(
+      'throws if %s is missing from the payload',
+      (prop) => {
+        const invalidOptions = Object.assign({}, options);
+        delete invalidOptions[prop];
+        expect(() =>
+          CommandCreateListItemService.call(controller, invalidOptions, config)
+        ).toThrow(InvalidParametersError);
+      }
+    );
+  });
+});


### PR DESCRIPTION
There's a lot of endpoints that are not currently covered by the SDK. 
Would you be willing to accept this PR to extend that coverage?

I've searched other language SDKs and I couldn't find an implementation of this endpoint so I could copy the interface.
Not sure if this would be the naming you're after. If not, let me know and I can update it.