### PR TITLE
fix: make request_token and context optional based on skip parameters

### DIFF
--- a/src/payload/models/filter_payload.ts
+++ b/src/payload/models/filter_payload.ts
@@ -69,27 +69,3 @@ export type FilterPayload =
   | SkipRequestToken
   | SkipContext
   | SkipBoth;
-
-// Test cases
-export const test1: FilterPayload = {
-  type: '$custom',
-  matching_user_id: 'test',
-  name: 'test',
-  skip_request_token_validation: true, // request_token is optional
-  skip_context_validation: true, // context is optional
-};
-
-export const test2: FilterPayload = {
-  type: '$custom',
-  request_token: 'xXxXxXx',
-  name: 'test',
-  context: {
-    ip: '1.1.1.1',
-    headers: {
-      test1: false,
-      test2: true,
-    },
-  },
-  skip_request_token_validation: false,
-  skip_context_validation: false,
-};

--- a/src/payload/models/risk_payload.ts
+++ b/src/payload/models/risk_payload.ts
@@ -1,8 +1,7 @@
 import type { IncomingHttpHeaders } from 'http2';
 import type { AddressPayload } from './address_payload';
 
-export type RiskPayload = {
-  request_token: string;
+type BaseRiskPayload = {
   user: {
     id: string;
     phone?: string;
@@ -13,10 +12,6 @@ export type RiskPayload = {
     address?: { [key: string]: any };
   };
   properties?: { [key: string]: any };
-  context: {
-    ip: string;
-    headers: IncomingHttpHeaders | { [key: string]: string | boolean };
-  };
   created_at?: string;
   product?: {
     id: string;
@@ -37,3 +32,42 @@ export type RiskPayload = {
   skip_request_token_validation?: boolean;
   skip_context_validation?: boolean;
 } & ({ event: string } | { type: string });
+
+type Context = {
+  ip: string;
+  headers: IncomingHttpHeaders | { [key: string]: string | boolean };
+};
+
+type RequiredContextAndToken = BaseRiskPayload & {
+  request_token: string;
+  context: Context;
+  skip_request_token_validation?: false;
+  skip_context_validation?: false;
+};
+
+type SkipRequestToken = BaseRiskPayload & {
+  request_token?: string;
+  context: Context;
+  skip_request_token_validation: true;
+  skip_context_validation?: false;
+};
+
+type SkipContext = BaseRiskPayload & {
+  request_token: string;
+  context?: Context;
+  skip_request_token_validation?: false;
+  skip_context_validation: true;
+};
+
+type SkipBoth = BaseRiskPayload & {
+  request_token?: string;
+  context?: Context;
+  skip_request_token_validation: true;
+  skip_context_validation: true;
+};
+
+export type RiskPayload =
+  | RequiredContextAndToken
+  | SkipRequestToken
+  | SkipContext
+  | SkipBoth;


### PR DESCRIPTION
As specified in the [Protecting Out-of-Band Actions](https://docs.castle.io/docs/protecting-out-of-band-actions) section of the Castle documentation, if we need to make requests to the Filter/Risk API from the server side, we can pass the `skip_request_token_validation` or `skip_context_validation` parameters to make `request_token` and `context` optional. However, this behavior is not currently reflected in the type definitions, so we have to use `// @ts-expect-error` in our codebase.

This merge request updates the models so that when any of these skip parameters are passed, the corresponding field becomes optional.
